### PR TITLE
tolgo abilità nascosta di Kubfu

### DIFF
--- a/PokéAbil-data.lua
+++ b/PokéAbil-data.lua
@@ -1784,7 +1784,7 @@ t.zamazenta = {ability1 = 'Scudo Saldo'}
 t[889] = t.zamazenta
 t.eternatus = {ability1 = 'Pressione'}
 t[890] = t.eternatus
-t.kubfu = {ability1 = 'Forza Interiore', abilityd = 'Nessuna'}
+t.kubfu = {ability1 = 'Forza Interiore'}
 t[891] = t.kubfu
 t.urshifu = {ability1 = 'Pugni Invisibili'}
 t[892] = t.urshifu


### PR DESCRIPTION
questa cosa dovrebbe sistemare l'errorino segnalato da Marcodpat in [questa discussione](https://wiki.pokemoncentral.it/Discussione:Elenco_Pokémon_per_abilità#c-Marcodpat-20250509165700-Link_abilità_nascosta_di_Kubfu). Siccome però di moduli ne capisco troppo poco preferisco se qualcuno controlla prima editare il modulo vero.